### PR TITLE
Do not handle the response as 504 if timeout did not occur

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Plack::Middleware::Timeout.
 
+0.10 2020-10-14
+	- do not handle the response as 504 if timeout did not occur
+
 0.09 2017-09-02
 	- corrected the documentation
 	- using a better default response code 504 Gateway Timeout, 408 Request Timeout

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,6 +11,7 @@ WriteMakefile(
         'Time::HiRes'  => 0,
         'Test::More'    => 0,
         'HTTP::Message' => 0,
+        'Try::Tiny'     => 0,
     },
     BUILD_REQUIRES => {
         'Test::More'    => 0,


### PR DESCRIPTION
Plack::Middleware::Timeout should only trigger its response handling if the timeout has been actually reached. In any other case, let other middlewares handle the problem.

Fixes https://rt.cpan.org/Public/Bug/Display.html?id=133535

Notes:

- I don't know how to write a unit test for this case. I let you take care of this.
- I don't know how to achieve this without `Try::Tiny`. If there's a way, and you feel like skipping Try::Tiny is valuable, then please feel free to rewrite accordingly.